### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/build-chromium.yml
+++ b/.github/workflows/build-chromium.yml
@@ -26,7 +26,7 @@ jobs:
       - ${{ matrix.al_version }}
     steps:
       - name: Checkout this repo for Amazon Linux 2023
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: ./.github/actions/install-python
       - uses: ./.github/actions/clone-source
       - uses: ./.github/actions/sync-source-dependencies

--- a/.github/workflows/deploy-runner.yml
+++ b/.github/workflows/deploy-runner.yml
@@ -17,26 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout this repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: 22
         cache: "npm"        
     - name: Install dependencies
       run: npm ci        
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
       with:
         role-to-assume: ${{ vars.AWS_GITHUB_ACTIONS_ROLE }}
         aws-region: ${{ vars.AWS_TARGET_REGION }}
     - name: cdk synth
-      uses: tj-actions/aws-cdk@v4
+      uses: tj-actions/aws-cdk@e9c2b94df8f54b99318ba2728331a54c081874b0  # v4
       with:
         cdk_subcommand: "synth"
         cdk_stack: "ChromiumBuilderStack"
     - name: Deploy RunnerStack (via CDK)
-      uses: tj-actions/aws-cdk@v4
+      uses: tj-actions/aws-cdk@e9c2b94df8f54b99318ba2728331a54c081874b0  # v4
       with:
         cdk_subcommand: "deploy"
         cdk_stack: "ChromiumBuilderStack"


### PR DESCRIPTION
Pins GitHub Actions in \`.github/workflows\` to the full commit SHA their tag currently points to, keeping the original ref as a trailing comment.

This is a security hardening change ([pinning third-party actions to a full-length SHA](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)) — the resolved versions are unchanged, only made immutable.

### Pinned
```
actions/checkout@v4 -> 34e114876b0b11c390a56381ad16ebd13914f8d5
actions/setup-node@v4 -> 49933ea5288caeca8642d1e84afbd3f7d6820020
aws-actions/configure-aws-credentials@v4 -> 7474bc4690e29a8392af63c5b98e7449536d5c3a
tj-actions/aws-cdk@v4 -> e9c2b94df8f54b99318ba2728331a54c081874b0
tj-actions/aws-cdk@v4 -> e9c2b94df8f54b99318ba2728331a54c081874b0
actions/checkout@v4 -> 34e114876b0b11c390a56381ad16ebd13914f8d5
```

_Opened automatically by the Pin Actions To SHA maintenance workflow._